### PR TITLE
Prevent a nil error by only adding secrets that exist.

### DIFF
--- a/lib/cloudshaper/provider.rb
+++ b/lib/cloudshaper/provider.rb
@@ -6,7 +6,9 @@ module Cloudshaper
   class Provider < StackElement
     def load_secrets(name)
       @secrets ||= {}
-      @secrets[name.to_sym] = SECRETS[name.to_sym]
+      if SECRETS.has_key? name.to_sym
+        @secrets[name.to_sym] = SECRETS[name.to_sym]
+      end
       @secrets
     end
   end


### PR DESCRIPTION
If you have no `secrets.json` or you missed having secrets for a provider, things would break with a nil error in [command.rb](https://github.com/dalehamel/terraform_dsl/blob/2ecd10cef1327f40c6f670973cca5d57e5333751/lib/terraform_dsl/command.rb#L16).

We can either check for nil there, or prevent a nil secrets hash from leaving `Provider::load_secrets` (which is what I did in this PR). I prefer the latter because a provider doesn't necessarily require secrets (e.g., local docker), so we should probably prevent a nil value from ever escaping `load_secrets`.

@dalehamel @wvanbergen
