### PR TITLE
Add minitest equivalents for the commented out rspec tests.

### DIFF
--- a/lib/cloudshaper/stack_modules.rb
+++ b/lib/cloudshaper/stack_modules.rb
@@ -16,7 +16,7 @@ module Cloudshaper
       end
 
       def reset!
-        @stack_modules ||= {}
+        @stack_modules = {}
       end
     end
     reset!


### PR DESCRIPTION
Take care of a couple of lingering commented-out tests. The commented out test at the bottom was already written for minitest, so I just deleted the whole comment block. I also added a test setup method to reset the stack modules so that if someone did happen to use the same name twice in the test module, it's okay (state persisting from test to test is undesirable).

@dalehamel @wvanbergen @xthexder 
