### PR TITLE
Clean up code by reducing the exposure of underlying hashes.

### DIFF
--- a/lib/cloudshaper/command.rb
+++ b/lib/cloudshaper/command.rb
@@ -11,7 +11,7 @@ module Cloudshaper
 
     def env
       vars = {}
-      @stack.variables.each { |k, v| vars["TF_VAR_#{k}"] = v[:default] }
+      @stack.module.each_variable { |k, v| vars["TF_VAR_#{k}"] = v[:default] }
       @stack.module.secrets.each do |_provider, secrets|
         secrets.each do |k, v|
           vars[k.to_s] = v

--- a/lib/cloudshaper/stack.rb
+++ b/lib/cloudshaper/stack.rb
@@ -20,15 +20,17 @@ module Cloudshaper
                 :stack_dir, :stack_id, :remote
 
     def initialize(config)
-      @name = config['name']
-      @uuid = config['uuid']
-      @description = config['description'] || ''
-      @variables = config['variables'] || {}
+      @name = config.fetch('name')
+      @uuid = config.fetch('uuid')
       @remote = config['remote'] || {}
+      @description = config['description'] || ''
+
       @stack_id = "cloudshaper#{@name}_#{@uuid}"
-      @module = StackModules.get(config['root'])
-      @variables['cloudshaper_stack_id'] = @stack_id
       @stack_dir = File.join(Stacks.dir, @stack_id)
+
+      @module = StackModules.get(config.fetch('root'))
+      @variables = config['variables'] || {}
+      @variables['cloudshaper_stack_id'] = @stack_id
       @module.build(@variables.map { |k, v| [k.to_sym, v] }.to_h)
     end
 
@@ -62,10 +64,6 @@ module Cloudshaper
 
     def remote_config
       Remote.new(self, :config).execute
-    end
-
-    def variables
-      @module.variables
     end
 
     def to_s

--- a/lib/cloudshaper/stack_module.rb
+++ b/lib/cloudshaper/stack_module.rb
@@ -55,17 +55,23 @@ module Cloudshaper
       JSON.pretty_generate(elements)
     end
 
-    def variables
-      elements[:variable]
-    end
-
-    def outputs
-      @stack_elements[:output]
+    def id
+      get(:terraform_stack_id)
     end
 
     def get(variable)
-      @stack_elements[:variable].fetch(variable)[:default]
+      elements[:variable].fetch(variable)[:default]
     end
+
+    def each_variable(&b)
+      elements[:variable].each(&b)
+    end
+
+    def get_resource(type, id)
+      @stack_elements[:resource].fetch(type).fetch(id)
+    end
+
+    private
 
     def elements
       elements = @stack_elements.clone
@@ -76,12 +82,6 @@ module Cloudshaper
       elements[:variable] = variables
       elements
     end
-
-    def id
-      get(:terraform_stack_id)
-    end
-
-    private
 
     def register_resource(resource_type, name, &block)
       @stack_elements[:resource] ||= {}
@@ -112,10 +112,10 @@ module Cloudshaper
       @stack_elements[:provider][name.to_sym] = provider.fields
     end
 
-    alias_method :resource, :register_resource
-    alias_method :variable, :register_variable
-    alias_method :provider, :register_provider
-    alias_method :output,   :register_output
-    alias_method :submodule,    :register_module
+    alias_method :resource,  :register_resource
+    alias_method :variable,  :register_variable
+    alias_method :provider,  :register_provider
+    alias_method :output,    :register_output
+    alias_method :submodule, :register_module
   end
 end


### PR DESCRIPTION
Had this sitting around from last week.
- A few more fetches on the resource hashes, so we won't get weird `nil` errors.
- `each_variable` may have been overkill, so let me know if you'd still like to keep a `variables` method.

@wvanbergen @dalehamel @xthexder 
