### PR TITLE
Support required variables in modules.

### DIFF
--- a/lib/cloudshaper/stack_module.rb
+++ b/lib/cloudshaper/stack_module.rb
@@ -36,7 +36,7 @@ module Cloudshaper
       @stack_elements = { resource: {}, provider: {}, variable: {}, output: {}, module: {} }
       @secrets = {}
       @block = block
-      variable(:terraform_stack_id) {}
+      variable(:terraform_stack_id) { default '' }
     end
 
     def clone
@@ -90,9 +90,15 @@ module Cloudshaper
     end
 
     def register_variable(name, &block)
+      return if @stack_elements[:variable].key?(name)
+
       new_variable = Cloudshaper::Variable.new(self, &block).fields
-      unless @stack_elements[:variable].key?(name.to_sym)
-        @stack_elements[:variable][name.to_sym] = { default: new_variable[:default] || '' }
+      if new_variable[:default].nil?
+        @stack_elements[:variable][name.to_sym] = {}
+      else
+        @stack_elements[:variable][name.to_sym] = {
+          default: new_variable[:default]
+        }
       end
     end
 

--- a/test/stack_module_test.rb
+++ b/test/stack_module_test.rb
@@ -46,11 +46,11 @@ class StackModuleTest < Minitest::Test
     assert_equal 'spam', mod.get(:name)
   end
 
-  def test_module_build_registers_variables_without_defaults
-    mod = StackModule.define('variable_register_nodefault') { variable(:name) {} }
+  def test_required_variable_has_no_default_value
+    mod = StackModule.define('resource_required_variable') { variable(:name) {} }
     mod.build
 
-    assert_equal '', mod.get(:name)
+    assert_nil mod.get(:name)
   end
 
   def test_module_build_registers_variables_at_runtime


### PR DESCRIPTION
To have parity with terraform, and because there should be required variables.

@wvanbergen @dalehamel
