### PR TITLE
Add a function to simplify reference list variables.

### DIFF
--- a/lib/cloudshaper/stack_element.rb
+++ b/lib/cloudshaper/stack_element.rb
@@ -38,6 +38,11 @@ module Cloudshaper
       "${var.#{variable_name}}"
     end
 
+    # Reference a list variable
+    def var_list(variable_name)
+      ["${split(\",\",var.#{variable_name})}"]
+    end
+
     # Syntax to handle interpolation of resource variables
     def value_of(resource_type, resource_name, value_type)
       "${#{resource_type}.#{resource_name}.#{value_type}}"


### PR DESCRIPTION
As per the discussion in hashicorp/terraform#57, this is the workaround for referencing a variable that should have a list value. Not sure if you guys are for/against this, but it's nice to be able to express things as lists in `stacks.yaml`. For example, with RDS instances you can specify the subnets in which the instances will run. Another example is the use of multiple CIDR blocks for ingress/egress rules in a security group.

@dalehamel @wvanbergen
