### PR TITLE
Fixes a bug where submodules would be built incorrectly.

### DIFF
--- a/lib/cloudshaper/stack_module.rb
+++ b/lib/cloudshaper/stack_module.rb
@@ -30,13 +30,14 @@ module Cloudshaper
       end
     end
 
-    attr_accessor :secrets
+    attr_accessor :name, :secrets
 
-    def initialize(_name, &block)
+    def initialize(name, &block)
+      @name = name
       @stack_elements = { resource: {}, provider: {}, variable: {}, output: {}, module: {} }
       @secrets = {}
       @block = block
-      variable(:terraform_stack_id) { default '' }
+      variable(:cloudshaper_stack_id) { default '' }
     end
 
     def clone
@@ -56,7 +57,7 @@ module Cloudshaper
     end
 
     def id
-      get(:terraform_stack_id)
+      get(:cloudshaper_stack_id)
     end
 
     def get(variable)
@@ -108,7 +109,7 @@ module Cloudshaper
     end
 
     def register_module(name, &block)
-      new_module = Cloudshaper::Module.new(self, name, &block).fields
+      new_module = Cloudshaper::Module.new(self, &block).fields
       @stack_elements[:module][name.to_sym] = new_module
     end
 

--- a/lib/cloudshaper/stack_modules.rb
+++ b/lib/cloudshaper/stack_modules.rb
@@ -10,6 +10,10 @@ module Cloudshaper
         @stack_modules[name.downcase] = stack_module
       end
 
+      def has?(stack_module_name)
+        @stack_modules.key?(stack_module_name.downcase)
+      end
+
       def get(stack_module_name)
         fail ModuleNotFound, "#{stack_module_name} module module not found" unless @stack_modules.key?(stack_module_name.downcase)
         @stack_modules[stack_module_name.downcase].clone


### PR DESCRIPTION
Specifically, when you use a submodule, it would look something like this:

```
Cloudshaper::StackModule.define 'submodules' do
  submodule(:mod_a) { source 'module_mod_a' }
  submodule(:mod_b) do
    source 'module_mod_b'
    input_b value_of(:module, :mod_a, :output_a)
  end
end
```

but we want to restrict the interpolated `input_b` value to the `submodules` module and not pass it along when building `mod_b` itself. I'm not sure if there's a case where we would want to build a submodule with variables other than the stack id (I don't think so).

Also, I renamed `terraform_stack_id` to `cloudshaper_stack_id`, as I'm fairly certain this concept is specific to Cloudshaper (correct me if I'm wrong).

@wvanbergen @dalehamel @xthexder 
