### PR TITLE
Use env vars to get input values into root module.

### DIFF
--- a/lib/cloudshaper/command.rb
+++ b/lib/cloudshaper/command.rb
@@ -1,3 +1,5 @@
+require 'cloudshaper/secrets'
+
 module Cloudshaper
   # Wraps terraform command execution
   class Command
@@ -11,8 +13,8 @@ module Cloudshaper
 
     def env
       vars = {}
-      @stack.module.each_variable { |k, v| vars["TF_VAR_#{k}"] = v[:default] }
-      @stack.module.secrets.each do |_provider, secrets|
+      @stack.variables { |k, v| vars["TF_VAR_#{k}"] = v[:default] }
+      SECRETS.each do |_provider, secrets|
         secrets.each do |k, v|
           vars[k.to_s] = v
         end

--- a/lib/cloudshaper/provider.rb
+++ b/lib/cloudshaper/provider.rb
@@ -1,15 +1,6 @@
-require 'cloudshaper/secrets'
 require 'cloudshaper/stack_element'
 
 module Cloudshaper
-  # Implements DSL for a terraform provider, and a means of loading secrets.
-  class Provider < StackElement
-    def load_secrets(name)
-      @secrets ||= {}
-      if SECRETS.has_key? name.to_sym
-        @secrets[name.to_sym] = SECRETS[name.to_sym]
-      end
-      @secrets
-    end
-  end
+  # Implements DSL for a terraform provider.
+  class Provider < StackElement; end
 end

--- a/lib/cloudshaper/stack.rb
+++ b/lib/cloudshaper/stack.rb
@@ -16,8 +16,8 @@ module Cloudshaper
       end
     end
 
-    attr_reader :name, :description, :module,
-                :stack_dir, :stack_id, :remote
+    attr_reader :name, :description, :module, :stack_dir,
+                :stack_id, :remote, :variables
 
     def initialize(config)
       @name = config.fetch('name')
@@ -31,7 +31,6 @@ module Cloudshaper
       @module = StackModules.get(config.fetch('root'))
       @variables = config['variables'] || {}
       @variables['cloudshaper_stack_id'] = @stack_id
-      @module.build(@variables.map { |k, v| [k.to_sym, v] }.to_h)
     end
 
     def apply

--- a/lib/cloudshaper/stack_module.rb
+++ b/lib/cloudshaper/stack_module.rb
@@ -114,9 +114,8 @@ module Cloudshaper
     end
 
     def register_provider(name, &block)
-      provider = Cloudshaper::Provider.new(self, &block)
-      @secrets.merge!(provider.load_secrets(name))
-      @stack_elements[:provider][name.to_sym] = provider.fields
+      provider = Cloudshaper::Provider.new(self, &block).fields
+      @stack_elements[:provider][name.to_sym] = provider
     end
 
     alias_method :resource,  :register_resource


### PR DESCRIPTION
From the enlightenment gained in #12, this change makes the root module no different than submodules in that it takes inputs from the outside context (in this case, environment vars) instead of having inputs baked in as variables with default values.

Similarly, to make the provider more aligned with the other stack elements, we read the `SECRETS` hash directly when creating the environment.

@dalehamel @wvanbergen @xthexder 
